### PR TITLE
Fix "Webapp crashes on first launch if the cache is empty" (/issues/7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 setup:
-	pip install pytest pytest-cov flake8 twine
+	pip install pytest pytest-cov flake8 twine freezegun
 	pip install .
 
 clean-pyc:

--- a/pocket_stats/data.py
+++ b/pocket_stats/data.py
@@ -1,4 +1,5 @@
 import nltk
+import errno
 import os
 import json
 import logging
@@ -77,7 +78,9 @@ def fetch_data(offset: int = 0, limit: int = None, overwrite_cache: bool = False
 
 def load_cache(cache_file: str = CACHE_FILE) -> List[Dict]:
     if not os.path.isfile(cache_file):
-        return []
+        logging.error(f"Missing cache file, please run 'python -m pocket_stats fetch-data --overwrite_cache'")
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT),
+                                cache_file)
     with open(cache_file, 'r') as fi:
         return json.load(fi)
 

--- a/pocket_stats/data.py
+++ b/pocket_stats/data.py
@@ -78,7 +78,7 @@ def fetch_data(offset: int = 0, limit: int = None, overwrite_cache: bool = False
 
 def load_cache(cache_file: str = CACHE_FILE) -> List[Dict]:
     if not os.path.isfile(cache_file):
-        logging.error(f"Missing cache file, please run 'python -m pocket_stats fetch-data --overwrite_cache'")
+        logging.error("Missing cache file, please run 'python -m pocket_stats fetch-data --overwrite_cache'")
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT),
                                 cache_file)
     with open(cache_file, 'r') as fi:

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
         'tldextract',
         'pandas',
     ],
-    tests_require=['pytest', 'pytest-cov'],
+    tests_require=['pytest', 'pytest-cov', 'freezegun'],
     zip_safe=False
 )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -48,7 +48,8 @@ def data():
 
 
 def test_load_cache(data: List[Dict]):
-    assert load_cache('/this/path/is/invalid.cache') == []
+    with pytest.raises(FileNotFoundError):
+        load_cache('/this/path/is/invalid.cache')
     # no need to test with valid cached, because the fixture data already run load_cache(cache_file)
 
 
@@ -63,7 +64,7 @@ def test_fetch_data_ok(mocked_pocket_retrieve, mocked_open, mocked_json_dump):
 
 def test_fetch_data_failed():
     with pytest.raises(Exception):
-        fetch_data()
+        fetch_data(consumer_key='invalid', access_token='none')
 
 
 def raise_lookup_err_side_effect(*args, **kwargs):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,6 +4,7 @@ from typing import List, Dict
 from collections import Counter
 import pandas as pd
 from unittest.mock import patch
+from freezegun import freeze_time
 
 from pocket_stats.data import fetch_data, load_cache, is_valid_word, normalize_language_name, get_domain_from_url
 from pocket_stats.data import should_pass_filters, count_words_in_title, get_word_counts, get_favorite_count
@@ -136,6 +137,7 @@ def test_get_archived_time_series(data: List[Dict]):
     }}
 
 
+@freeze_time("2020-07-01")
 def test_get_average_readed_word(data: List[Dict]):
     assert get_average_readed_word(data, 30) == 2724.5
 


### PR DESCRIPTION
- Bug https://github.com/nlbao/pocket_stats/issues/7. Resolution: raise `FileNotFoundError` when the cache file doesn't exist.
- Also fixed bug with `datetime.now()` when testing `get_average_readed_word()`, using `freezegun`.